### PR TITLE
Updated parser and README with correct arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,17 @@ bangen "HELLO" --gradient "#ff0000:#ffff00:#00ff00" --gradient-dir vertical
 #### Discoverability
 
 ```bash
-bangen --list-effects
-bangen --list-fonts
-bangen --list-presets
+bangen main --list-effects
+bangen main --list-fonts
+bangen main --list-presets
 ```
 
 #### Presets and AI
 
 ```bash
-bangen --preset cyberpunk "HELLO"
-bangen --preset matrix "SYSTEM"
-bangen --preset-file ./my_preset.json "HELLO"
+bangen "HELLO" --preset cyberpunk
+bangen "SYSTEM" --preset matrix
+bangen "HELLO" --preset-file ./my_preset.json
 bangen "HELLO" --ai "retro CRT hacker title"
 ```
 

--- a/bangen/cli/parser.py
+++ b/bangen/cli/parser.py
@@ -21,14 +21,14 @@ app = typer.Typer(
         '  bangen "HELLO" --font slant --gradient "#ff00ff:#00ffff"\n'
         '  bangen "HELLO" --effect wave --effect chromatic_aberration --effect pulse --speed 1.5\n'
         '  bangen "HELLO" --screensaver\n'
-        '  bangen --preset neon_wave "HELLO"\n'
-        '  bangen --preset-file ./preset.json "HELLO"\n'
+        '  bangen "HELLO" --preset neon_wave\n'
+        '  bangen "HELLO" --preset-file ./preset.json\n'
         '  bangen "HELLO" --ai "cyberpunk neon hacker vibe"\n'
         '  bangen "HELLO" --export-png banner.png\n'
         '  bangen "HELLO" --export-gif banner.gif\n'
-        "  bangen --list-effects\n"
-        "  bangen --list-presets\n"
-        "  bangen --list-fonts"
+        "  bangen main --list-effects\n"
+        "  bangen main --list-presets\n"
+        "  bangen main --list-fonts"
     ),
 )
 

--- a/bangen/cli/parser.py
+++ b/bangen/cli/parser.py
@@ -26,9 +26,9 @@ app = typer.Typer(
         '  bangen "HELLO" --ai "cyberpunk neon hacker vibe"\n'
         '  bangen "HELLO" --export-png banner.png\n'
         '  bangen "HELLO" --export-gif banner.gif\n'
-        "  bangen main --list-effects\n"
-        "  bangen main --list-presets\n"
-        "  bangen main --list-fonts"
+        "  bangen --list-effects\n"
+        "  bangen --list-presets\n"
+        "  bangen --list-fonts"
     ),
 )
 


### PR DESCRIPTION
This corrects the parser help documentation and examples in the README with the correct argument order and adds the missing "main" argument.

Fixes #6 